### PR TITLE
Full report as .html

### DIFF
--- a/gocov.css
+++ b/gocov.css
@@ -1,0 +1,54 @@
+body {
+        margin: 0;
+        font-family: Helvetica, Arial, sans-serif;
+        font-size: 16px;
+}
+pre,
+code {
+        font-family: Menlo, monospace;
+        font-size: 14px;
+	color: "black";
+}
+pre {
+        line-height: 18px;
+}
+pre .hit {
+        background: #BCFAB9;
+}
+pre .miss {
+        background: #EDB9CE;
+}
+h1 {
+        font-size: 24px;
+}
+h2 {
+        font-size: 22px;
+        background: #E0EBF5;
+        padding: 2px 5px;
+}
+h3 {
+        font-size: 20px;
+}
+h3,
+h4 {
+        margin: 20px 5px;
+}
+h4 {
+        font-size: 16px;
+}
+table {
+	width: auto;
+}
+.total {
+	font-size: 18px;
+	font-weight: bold;
+}
+.function {
+	padding: 0px 25px;
+}
+.percentage {
+	width: auto;
+}
+.lines {
+	width: auto;
+}

--- a/gocov/html.go
+++ b/gocov/html.go
@@ -1,0 +1,44 @@
+// html.go
+package main
+
+import (
+	"fmt"
+	"io"
+	"github.com/axw/gocov"
+)
+
+func htmlReport() (rc int) {
+	html = true
+	return reportCoverage()
+}
+
+//WIP Gocov Test Coverage Report
+func printHeader(w io.Writer, title string) {
+	if html {
+		fmt.Fprintln(w, "<!DOCTYPE html>\n<HTML>\n<HEAD><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">")
+		fmt.Fprintf(w, "<LINK HREF=\"gocov.css\" rel=\"stylesheet\"><TITLE> %s </TITLE></HEAD><BODY>", title)
+	}
+}
+
+func printFooter(w io.Writer) {
+	if html {
+		fmt.Fprintln(w, "</BODY></HTML>")
+	}
+}
+
+func printPackageHeader(w io.Writer, pkg *gocov.Package) {
+	if html {
+		fmt.Fprintf(w, "<H2>%s</H2>\n", pkg.Name)
+		fmt.Fprintln(w, "<TABLE>")
+	}
+}
+
+func printPackageFooter(w io.Writer, reached int, total int, percentage float64) {
+	if html {
+		fmt.Fprintf(w,"<TR><TD></TD><TD class=\"function\">Total coverage</TD><TD class=\"total\">%.2f%%</TD><TD class=\"total\">(%d/%d)</TD></TR>\n", percentage, reached, total)
+		fmt.Fprintln(w, "</TABLE>\n")
+	} else {
+		fmt.Fprintf(w,"Total coverage: %.2f%% (%d/%d)\n", percentage, reached, total)
+	}
+	
+}

--- a/gocov/main.go
+++ b/gocov/main.go
@@ -48,6 +48,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "\tannotate\n")
 	fmt.Fprintf(os.Stderr, "\ttest\n")
 	fmt.Fprintf(os.Stderr, "\treport\n")
+	fmt.Fprintf(os.Stderr, "\thtmlreport\n")
 	fmt.Fprintf(os.Stderr, "\n")
 	flag.PrintDefaults()
 	os.Exit(2)
@@ -65,7 +66,9 @@ var (
 		"work", false,
 		"print the name of the temporary work directory "+
 			"and do not delete it when exiting")
-	verbose bool
+	verbose       bool
+	fullAnnotation bool = false
+	html       bool = false
 )
 
 func init() {
@@ -438,6 +441,8 @@ func main() {
 			os.Exit(annotateSource())
 		case "report":
 			os.Exit(reportCoverage())
+		case "htmlreport":
+			os.Exit(htmlReport())
 		case "test":
 			os.Exit(instrumentAndTest())
 		//case "run"


### PR DESCRIPTION
User can use

$ gocov htmlreport mycode.json > index.html

to generate an index.html with report data and the annotate
results for each function gets written into separate files in
the working directory.

Colours can be changed by editing the gocov.css file.

As a nice side effect added package total coverage into normal plain
report.
