### PR TITLE
Skip packages without tests

### DIFF
--- a/gocov/main.go
+++ b/gocov/main.go
@@ -316,7 +316,8 @@ func (in *instrumenter) instrumentPackage(pkgpath string, testPackage bool) erro
 	verbosef("instrumenting package %q\n", pkgpath)
 
 	if testPackage && len(buildpkg.TestGoFiles)+len(buildpkg.XTestGoFiles) == 0 {
-		return fmt.Errorf("no test files")
+		verbosef("skipping %q because no test files\n", buildpkg.Name)
+		return nil
 	}
 
 	// Set a "working directory", for resolving relative imports.


### PR DESCRIPTION
This pull request proposes to change the way packages without tests are handled. Instead of throwing an error, they  just get skipped. This is useful if you want to test a full application and in CI scenarios.
## Example

Consider the following go project that contains various packages. Some with tests, some without.

```
$ pwd
/Users/pjvds/dev/mygo/src/github.com/pjvds/go-cqrs
$ tree -d
. [no test files]
├── sourcing
├── storage
│   ├── eventstore
│   ├── memory
│   └── serialization [no test files]
└── tests
    ├── domain [no test files]
    └── events [no test files]
```
## Before

When running gocov with the `./...` command it fails when one of the packages does not have any tests. Here is an example:

```
$ gocov test ./...
failed to instrument package(github.com/pjvds/go-cqrs): no test files
```
## After

When running gocov with the `./...` command it skips packages without tests and generates a coverage.json succesfully. Here is an example:

```
$ gocov test ./... > coverage.json
?     github.com/pjvds/go-cqrs  [no test files]
ok    github.com/pjvds/go-cqrs/sourcing 0.027s
ok    github.com/pjvds/go-cqrs/storage  0.034s
ok    github.com/pjvds/go-cqrs/storage/eventstore 0.047s
ok    github.com/pjvds/go-cqrs/storage/memory 0.017s
?     github.com/pjvds/go-cqrs/storage/serialization  [no test files]
ok    github.com/pjvds/go-cqrs/tests  0.026s
?     github.com/pjvds/go-cqrs/tests/domain [no test files]
?     github.com/pjvds/go-cqrs/tests/events [no test files]
```

When running gocov to run for a single package, it still fails nicely:

```
gocov test > package.json
error: no packages were instrumented
```
