### PR TITLE
Gocov fails if the target imports gocov itself.

### DIFF
--- a/gocov/instrument.go
+++ b/gocov/instrument.go
@@ -232,7 +232,7 @@ func (in *instrumenter) instrumentFile(f *ast.File, fset *token.FileSet, pkgpath
 	var vardecls []ast.Decl
 	pkgvarname := fmt.Sprint(pkgObj)
 	if pkgCreated {
-		value := makeCall("gocov.RegisterPackage", makeLit(pkgpath))
+		value := makeCall("_gocov.RegisterPackage", makeLit(pkgpath))
 		vardecls = append(vardecls, makeVarDecl(pkgvarname, value))
 	}
 	for _, fn := range state.functions {
@@ -259,7 +259,7 @@ func (in *instrumenter) instrumentFile(f *ast.File, fset *token.FileSet, pkgpath
 	// Add a "gocov" import.
 	if pkgCreated {
 		gocovImportSpec := &ast.ImportSpec{
-			Path: makeLit(gocovPackagePath).(*ast.BasicLit)}
+			Path: makeLit(gocovPackagePath).(*ast.BasicLit), Name: ast.NewIdent("_gocov")}
 		gocovImportGenDecl := &ast.GenDecl{
 			Tok: token.IMPORT, Specs: []ast.Spec{gocovImportSpec}}
 		tail := make([]ast.Decl, len(f.Decls)-nImportDecls)


### PR DESCRIPTION
Hi, I'm writing a test for the package that uses gocov: https://github.com/t-yuki/gocov-xml/blob/master/gocov-xml.go
When I run `gocov test` with this to measure coverages, gocov failed with an error.
It seems that gocov's instrumented source code has duplicated import path or name `gocov`.

To solve this problem, I think there are two approches:
1. Rename import name of gocov in user code (gocov-xml in this case). User code should not use the reserved import name `gocov`, as a limitation.
2. Rename import name of gocov in gocov instrumentor. User code can use all names unless it conflicts  unfortunately.

I suppose 2. is better because user code should not depend on the implementation of instrumentor.
However, in this case, the user code intrinsically depends on gocov so 1. is also reasonable.

I send a pull request of 2 by renaming it to an unusual name, but I leave it in your hands.

``` shell
gocov test -v --work
WORK=/tmp/gocov478759733                                                                                     
instrumenting package "github.com/t-yuki/gocov-xml"
github.com/axw/gocov
# github.com/t-yuki/gocov-xml
/tmp/gocov478759733/src/pkg/github.com/t-yuki/gocov-xml/gocov-xml.go:16: gocov redeclared as imported package name
        previous declaration at /tmp/gocov478759733/src/pkg/github.com/t-yuki/gocov-xml/gocov-xml.go:14
FAIL    github.com/t-yuki/gocov-xml [build failed]
go test failed: exit status 2
```
