### PR TITLE
added red color to misses and a flag to turn this on (off by default)

### DIFF
--- a/gocov/annotate.go
+++ b/gocov/annotate.go
@@ -37,6 +37,9 @@ import (
 const (
 	hitPrefix  = "    "
 	missPrefix = "MISS"
+	RED = "\x1b[31;1m"
+	GREEN = "\x1b[32;1m"
+	NONE = "\x1b[0m"
 )
 
 var (
@@ -44,181 +47,188 @@ var (
 	annotateCeilingFlag = annotateFlags.Float64(
 		"ceiling", 101,
 		"Annotate only functions whose coverage is less than the specified percentage")
-)
+	annotateColorFlag	= annotateFlags.Bool(
+		"color", false,
+		"Differenciate Coverage with color")
+	)
 
-type packageList []*gocov.Package
-type functionList []*gocov.Function
+	type packageList []*gocov.Package
+	type functionList []*gocov.Function
 
-func (l packageList) Len() int {
-	return len(l)
-}
-
-func (l packageList) Less(i, j int) bool {
-	return l[i].Name < l[j].Name
-}
-
-func (l packageList) Swap(i, j int) {
-	l[i], l[j] = l[j], l[i]
-}
-
-func (l functionList) Len() int {
-	return len(l)
-}
-
-func (l functionList) Less(i, j int) bool {
-	return l[i].Name < l[j].Name
-}
-
-func (l functionList) Swap(i, j int) {
-	l[i], l[j] = l[j], l[i]
-}
-
-type annotator struct {
-	fset  *token.FileSet
-	files map[string]*token.File
-}
-
-func percentReached(fn *gocov.Function) float64 {
-	if len(fn.Statements) == 0 {
-		return 0
+	func (l packageList) Len() int {
+		return len(l)
 	}
-	var reached int
-	for _, stmt := range fn.Statements {
-		if stmt.Reached > 0 {
-			reached++
+
+	func (l packageList) Less(i, j int) bool {
+		return l[i].Name < l[j].Name
+	}
+
+	func (l packageList) Swap(i, j int) {
+		l[i], l[j] = l[j], l[i]
+	}
+
+	func (l functionList) Len() int {
+		return len(l)
+	}
+
+	func (l functionList) Less(i, j int) bool {
+		return l[i].Name < l[j].Name
+	}
+
+	func (l functionList) Swap(i, j int) {
+		l[i], l[j] = l[j], l[i]
+	}
+
+	type annotator struct {
+		fset  *token.FileSet
+		files map[string]*token.File
+	}
+
+	func percentReached(fn *gocov.Function) float64 {
+		if len(fn.Statements) == 0 {
+			return 0
 		}
-	}
-	return float64(reached) / float64(len(fn.Statements)) * 100
-}
-
-func annotateSource() (rc int) {
-	annotateFlags.Parse(os.Args[2:])
-	if annotateFlags.NArg() == 0 {
-		fmt.Fprintf(os.Stderr, "missing coverage file\n")
-		return 1
+		var reached int
+		for _, stmt := range fn.Statements {
+			if stmt.Reached > 0 {
+				reached++
+			}
+		}
+		return float64(reached) / float64(len(fn.Statements)) * 100
 	}
 
-	var data []byte
-	var err error
-	if filename := annotateFlags.Arg(0); filename == "-" {
-		data, err = ioutil.ReadAll(os.Stdin)
-	} else {
-		data, err = ioutil.ReadFile(filename)
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to read coverage file: %s\n", err)
-		return 1
-	}
+	func annotateSource() (rc int) {
+		annotateFlags.Parse(os.Args[2:])
+		if annotateFlags.NArg() == 0 {
+			fmt.Fprintf(os.Stderr, "missing coverage file\n")
+			return 1
+		}
 
-	packages, err := unmarshalJson(data)
-	if err != nil {
-		fmt.Fprintf(
-			os.Stderr, "failed to unmarshal coverage data: %s\n", err)
-		return 1
-	}
-
-	// Sort packages, functions by name.
-	sort.Sort(packageList(packages))
-	for _, pkg := range packages {
-		sort.Sort(functionList(pkg.Functions))
-	}
-
-	a := &annotator{}
-	a.fset = token.NewFileSet()
-	a.files = make(map[string]*token.File)
-
-	var regexps []*regexp.Regexp
-	for _, arg := range annotateFlags.Args()[1:] {
-		re, err := regexp.Compile(arg)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to compile %q as a regular expression, ignoring\n", arg)
+		var data []byte
+		var err error
+		if filename := annotateFlags.Arg(0); filename == "-" {
+			data, err = ioutil.ReadAll(os.Stdin)
 		} else {
-			regexps = append(regexps, re)
+			data, err = ioutil.ReadFile(filename)
 		}
-	}
-	if len(regexps) == 0 {
-		regexps = append(regexps, regexp.MustCompile("."))
-	}
-	for _, pkg := range packages {
-		for _, fn := range pkg.Functions {
-			if percentReached(fn) >= *annotateCeilingFlag {
-				continue
-			}
-			name := pkg.Name + "/" + fn.Name
-			for _, regexp := range regexps {
-				if regexp.FindStringIndex(name) != nil {
-					err := a.printFunctionSource(fn)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "warning: failed to annotate function %q\n", name)
-					}
-					break
-				}
-			}
-		}
-	}
-	return
-}
-
-func (a *annotator) printFunctionSource(fn *gocov.Function) error {
-	// Load the file for line information. Probably overkill, maybe
-	// just compute the lines from offsets in here.
-	setContent := false
-	file := a.files[fn.File]
-	if file == nil {
-		info, err := os.Stat(fn.File)
 		if err != nil {
-			return err
+			fmt.Fprintf(os.Stderr, "failed to read coverage file: %s\n", err)
+			return 1
 		}
-		file = a.fset.AddFile(fn.File, a.fset.Base(), int(info.Size()))
-		setContent = true
-	}
 
-	data, err := ioutil.ReadFile(fn.File)
-	if err != nil {
-		return err
-	}
-	if setContent {
-		// This processes the content and records line number info.
-		file.SetLinesForContent(data)
-	}
-
-	statements := fn.Statements[:]
-	lineno := file.Line(file.Pos(fn.Start))
-	lines := strings.Split(string(data)[fn.Start:fn.End], "\n")
-	linenoWidth := int(math.Log10(float64(lineno+len(lines)))) + 1
-	fmt.Println()
-	for i, line := range lines {
-		// Go through statements one at a time, seeing if we've hit
-		// them or not.
-		//
-		// The prefix approach isn't perfect, as it doesn't
-		// distinguish multiple statements per line. It'll have to
-		// do for now. We could do fancy ANSI colouring later.
-		lineno := lineno + i
-		statementFound := false
-		hit := false
-		for j := 0; j < len(statements); j++ {
-			start := file.Line(file.Pos(statements[j].Start))
-			// FIXME instrumentation no longer records statements
-			// in line order, as function literals are processed
-			// after the body of a function. If/when that's changed,
-			// we can go back to checking just the first statement
-			// in each loop.
-			if start == lineno {
-				statementFound = true
-				if !hit && statements[j].Reached > 0 {
-					hit = true
-				}
-				statements = append(statements[:j], statements[j+1:]...)
+		packages, err := unmarshalJson(data)
+		if err != nil {
+			fmt.Fprintf(
+				os.Stderr, "failed to unmarshal coverage data: %s\n", err)
+				return 1
 			}
-		}
-		hitmiss := hitPrefix
-		if statementFound && !hit {
-			hitmiss = missPrefix
-		}
-		fmt.Printf("%*d %s\t%s\n", linenoWidth, lineno, hitmiss, line)
-	}
-	fmt.Println()
 
-	return nil
-}
+			// Sort packages, functions by name.
+			sort.Sort(packageList(packages))
+			for _, pkg := range packages {
+				sort.Sort(functionList(pkg.Functions))
+			}
+
+			a := &annotator{}
+			a.fset = token.NewFileSet()
+			a.files = make(map[string]*token.File)
+
+			var regexps []*regexp.Regexp
+			for _, arg := range annotateFlags.Args()[1:] {
+				re, err := regexp.Compile(arg)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "warning: failed to compile %q as a regular expression, ignoring\n", arg)
+				} else {
+					regexps = append(regexps, re)
+				}
+			}
+			if len(regexps) == 0 {
+				regexps = append(regexps, regexp.MustCompile("."))
+			}
+			for _, pkg := range packages {
+				for _, fn := range pkg.Functions {
+					if percentReached(fn) >= *annotateCeilingFlag {
+						continue
+					}
+					name := pkg.Name + "/" + fn.Name
+					for _, regexp := range regexps {
+						if regexp.FindStringIndex(name) != nil {
+							err := a.printFunctionSource(fn)
+							if err != nil {
+								fmt.Fprintf(os.Stderr, "warning: failed to annotate function %q\n", name)
+							}
+							break
+						}
+					}
+				}
+			}
+			return
+		}
+
+		func (a *annotator) printFunctionSource(fn *gocov.Function) error {
+			// Load the file for line information. Probably overkill, maybe
+			// just compute the lines from offsets in here.
+			setContent := false
+			file := a.files[fn.File]
+			if file == nil {
+				info, err := os.Stat(fn.File)
+				if err != nil {
+					return err
+				}
+				file = a.fset.AddFile(fn.File, a.fset.Base(), int(info.Size()))
+				setContent = true
+			}
+
+			data, err := ioutil.ReadFile(fn.File)
+			if err != nil {
+				return err
+			}
+			if setContent {
+				// This processes the content and records line number info.
+				file.SetLinesForContent(data)
+			}
+
+			statements := fn.Statements[:]
+			lineno := file.Line(file.Pos(fn.Start))
+			lines := strings.Split(string(data)[fn.Start:fn.End], "\n")
+			linenoWidth := int(math.Log10(float64(lineno+len(lines)))) + 1
+			fmt.Println()
+			for i, line := range lines {
+				// Go through statements one at a time, seeing if we've hit
+				// them or not.
+				//
+				// The prefix approach isn't perfect, as it doesn't
+				// distinguish multiple statements per line. It'll have to
+				// do for now. We could do fancy ANSI colouring later.
+				lineno := lineno + i
+				statementFound := false
+				hit := false
+				for j := 0; j < len(statements); j++ {
+					start := file.Line(file.Pos(statements[j].Start))
+					// FIXME instrumentation no longer records statements
+					// in line order, as function literals are processed
+					// after the body of a function. If/when that's changed,
+					// we can go back to checking just the first statement
+					// in each loop.
+					if start == lineno {
+						statementFound = true
+						if !hit && statements[j].Reached > 0 {
+							hit = true
+						}
+						statements = append(statements[:j], statements[j+1:]...)
+					}
+				}
+				color := NONE
+				hitmiss := hitPrefix
+				if statementFound && !hit {
+					hitmiss = missPrefix
+					if *annotateColorFlag {
+						color = RED
+					}
+				}
+				fmt.Printf("%s%*d %s\t%s%s\n", color, linenoWidth, lineno, hitmiss, line, NONE)
+			}
+			fmt.Println()
+
+			return nil
+		}


### PR DESCRIPTION
Added ANSI Color to misses and a flag to turn this on. I know this is a larger task than what I have done, but thought it would be good to push this now and get some feedback before I go whole hog into it. Right now it paints the whole miss line red if you have it turned on. I want to add support for partial line coloring and add support for lines that are not tested but don't need to be (struct declarations and the like). 
