### PR TITLE
added red color to misses and a flag to turn this on (off by default)

### DIFF
--- a/gocov/annotate.go
+++ b/gocov/annotate.go
@@ -49,7 +49,7 @@ var (
 		"Annotate only functions whose coverage is less than the specified percentage")
 	annotateColorFlag = annotateFlags.Bool(
 		"color", false,
-		"Differentiate Coverage with color")
+		"Differentiate coverage with color")
 )
 
 type packageList []*gocov.Package


### PR DESCRIPTION
Added ANSI Color to misses and a flag to turn this on. I know this is a larger task than what I have done, but thought it would be good to push this now and get some feedback before I go whole hog into it. Right now it paints the whole miss line red if you have it turned on. I want to add support for partial line coloring and add support for lines that are not tested but don't need to be (struct declarations and the like). 
