### PR TITLE
`gocov convert` supporting more than one profile

### DIFF
--- a/gocov/main.go
+++ b/gocov/main.go
@@ -67,7 +67,7 @@ func main() {
 				fmt.Fprintln(os.Stderr, "missing cover profile")
 				os.Exit(1)
 			}
-			if err := convertProfiles(flag.Args()[1]); err != nil {
+			if err := convertProfiles(flag.Args()[1:]...); err != nil {
 				fmt.Fprintln(os.Stderr, "error: %v", err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
So you can convert all profiles in one output:

```
$ gocov convert *
$ gocov convert profile1 profile2 ...
```
