### PR TITLE
Split test flags as in go test

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,3 +18,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+-------------------------------------------------------------------------------
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/gocov/internal/testflag/testflag.go
+++ b/gocov/internal/testflag/testflag.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2015 The Gocov Authors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// Parts of this taken from cmd/go/testflag.go and
+// cmd/go/build.go; adapted for simplicity.
+//
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testflag
+
+import "strings"
+
+type testFlagSpec struct {
+	name   string
+	isBool bool
+}
+
+var testFlagDefn = []*testFlagSpec{
+	// test-specific
+	{name: "i", isBool: true},
+	{name: "bench"},
+	{name: "benchmem", isBool: true},
+	{name: "benchtime"},
+	{name: "cpu"},
+	{name: "cpuprofile"},
+	{name: "memprofile"},
+	{name: "memprofilerate"},
+	{name: "blockprofile"},
+	{name: "blockprofilerate"},
+	{name: "parallel"},
+	{name: "run"},
+	{name: "short", isBool: true},
+	{name: "timeout"},
+	{name: "trace"},
+	{name: "v", isBool: true},
+
+	// common build flags
+	{name: "a", isBool: true},
+	{name: "race", isBool: true},
+	{name: "x", isBool: true},
+	{name: "asmflags"},
+	{name: "buildmode"},
+	{name: "compiler"},
+	{name: "gccgoflags"},
+	{name: "gcflags"},
+	{name: "ldflags"},
+	{name: "linkshared", isBool: true},
+	{name: "pkgdir"},
+	{name: "tags"},
+	{name: "toolexec"},
+}
+
+// Split processes the arguments , separating flags and package
+// names as done by "go test".
+func Split(args []string) (packageNames, passToTest []string) {
+	inPkg := false
+	for i := 0; i < len(args); i++ {
+		if !strings.HasPrefix(args[i], "-") {
+			if !inPkg && packageNames == nil {
+				// First package name we've seen.
+				inPkg = true
+			}
+			if inPkg {
+				packageNames = append(packageNames, args[i])
+				continue
+			}
+		}
+
+		if inPkg {
+			// Found an argument beginning with "-"; end of package list.
+			inPkg = false
+		}
+
+		n := parseTestFlag(args, i)
+		if n == 0 {
+			// This is a flag we do not know; we must assume
+			// that any args we see after this might be flag
+			// arguments, not package names.
+			inPkg = false
+			if packageNames == nil {
+				// make non-nil: we have seen the empty package list
+				packageNames = []string{}
+			}
+			passToTest = append(passToTest, args[i])
+			continue
+		}
+
+		passToTest = append(passToTest, args[i:i+n]...)
+		i += n - 1
+	}
+	return packageNames, passToTest
+}
+
+// parseTestFlag sees if argument i is a known flag and returns its
+// definition, value, and whether it consumed an extra word.
+func parseTestFlag(args []string, i int) (n int) {
+	arg := args[i]
+	if strings.HasPrefix(arg, "--") { // reduce two minuses to one
+		arg = arg[1:]
+	}
+	switch arg {
+	case "-?", "-h", "-help":
+		return 1
+	}
+	if arg == "" || arg[0] != '-' {
+		return 0
+	}
+	name := arg[1:]
+	// If there's already "test.", drop it for now.
+	name = strings.TrimPrefix(name, "test.")
+	equals := strings.Index(name, "=")
+	if equals >= 0 {
+		name = name[:equals]
+	}
+	for _, f := range testFlagDefn {
+		if name == f.name {
+			// Booleans are special because they have modes -x, -x=true, -x=false.
+			if !f.isBool && equals < 0 {
+				return 2
+			}
+			return 1
+		}
+	}
+	return 0
+}

--- a/gocov/internal/testflag/testflag_test.go
+++ b/gocov/internal/testflag/testflag_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2015 The Gocov Authors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+package testflag
+
+import (
+	"reflect"
+	"testing"
+)
+
+type test struct {
+	input        []string
+	packageNames []string
+	passToTest   []string
+}
+
+var tests = []test{{
+	input:        []string{"-v", "./subdir"},
+	packageNames: []string{"./subdir"},
+	passToTest:   []string{"-v"},
+}, {
+	input:        []string{"./subdir", "-v"},
+	packageNames: []string{"./subdir"},
+	passToTest:   []string{"-v"},
+}, {
+	input:        []string{"./...", "--", "positional", "-v"},
+	packageNames: []string{"./..."},
+	passToTest:   []string{"--", "positional", "-v"},
+}, {
+	input:        []string{"--", "positional", "-v"},
+	packageNames: []string{},
+	passToTest:   []string{"--", "positional", "-v"},
+}, {
+	input:        []string{"-tags", "a b c", "./..."},
+	packageNames: []string{"./..."},
+	passToTest:   []string{"-tags", "a b c"},
+}, {
+	input:        []string{"-tags", "a b c"},
+	packageNames: nil,
+	passToTest:   []string{"-tags", "a b c"},
+}, {
+	input:        []string{"-i=true", "-tags=a b c", "x", "y", "zzy", "-x"},
+	packageNames: []string{"x", "y", "zzy"},
+	passToTest:   []string{"-i=true", "-tags=a b c", "-x"},
+}, {
+	input:        []string{"-h", "-?", "-help"},
+	packageNames: nil,
+	passToTest:   []string{"-h", "-?", "-help"},
+}, {
+	input:        []string{"--v", "--tags=a b c", "pkgname"},
+	packageNames: []string{"pkgname"},
+	passToTest:   []string{"--v", "--tags=a b c"},
+}}
+
+func TestSplit(t *testing.T) {
+	for _, test := range tests {
+		t.Logf("testing: %q", test.input)
+		packageNames, passToTest := Split(test.input)
+		if !reflect.DeepEqual(packageNames, test.packageNames) {
+			t.Errorf("packageNames mismatch: %q != %q", packageNames, test.packageNames)
+		}
+		if !reflect.DeepEqual(passToTest, test.passToTest) {
+			t.Errorf("passToTest mismatch: %q != %q", passToTest, test.passToTest)
+		}
+	}
+}

--- a/gocov/test.go
+++ b/gocov/test.go
@@ -29,6 +29,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/axw/gocov/gocov/internal/testflag"
 )
 
 // resolvePackages returns a slice of resolved package names, given a slice of
@@ -54,19 +56,8 @@ func resolvePackages(pkgs []string) ([]string, error) {
 	return resolvedPkgs, nil
 }
 
-func splitPkgsFlags(args []string) ([]string, []string) {
-	flagIndex := len(args)
-	for i := range args {
-		if len(args[i]) > 0 && args[i][0] == '-' {
-			flagIndex = i
-			break
-		}
-	}
-	return args[:flagIndex], args[flagIndex:]
-}
-
 func runTests(args []string) error {
-	pkgs, testFlags := splitPkgsFlags(args)
+	pkgs, testFlags := testflag.Split(args)
 	pkgs, err := resolvePackages(pkgs)
 	if err != nil {
 		return err


### PR DESCRIPTION
I've adapted the code from cmd/go/testflag.go
to split package names and test flags, and
used that in "gocov test".