### PR TITLE
Add covermode to testFlagDefn

### DIFF
--- a/gocov/internal/testflag/testflag.go
+++ b/gocov/internal/testflag/testflag.go
@@ -40,6 +40,7 @@ var testFlagDefn = []*testFlagSpec{
 	{name: "bench"},
 	{name: "benchmem", isBool: true},
 	{name: "benchtime"},
+	{name: "covermode"},
 	{name: "cpu"},
 	{name: "cpuprofile"},
 	{name: "memprofile"},


### PR DESCRIPTION
goveralls passes this in, when I try to run it on a single sub-package bad things happen, this fixes that.