### PR TITLE
Fix order of args passing to go test

### DIFF
--- a/gocov/internal/testflag/testflag.go
+++ b/gocov/internal/testflag/testflag.go
@@ -72,7 +72,7 @@ var testFlagDefn = []*testFlagSpec{
 
 // Split processes the arguments , separating flags and package
 // names as done by "go test".
-func Split(args []string) (packageNames, passToTest []string) {
+func Split(args []string) (packageNames, passToTest []string, passToBin []string) {
 	inPkg := false
 	for i := 0; i < len(args); i++ {
 		if !strings.HasPrefix(args[i], "-") {
@@ -101,14 +101,18 @@ func Split(args []string) (packageNames, passToTest []string) {
 				// make non-nil: we have seen the empty package list
 				packageNames = []string{}
 			}
-			passToTest = append(passToTest, args[i])
+			if len(packageNames) > 0 {
+				passToBin = append(passToBin, args[i])
+			} else {
+				passToTest = append(passToTest, args[i])
+			}
 			continue
 		}
 
 		passToTest = append(passToTest, args[i:i+n]...)
 		i += n - 1
 	}
-	return packageNames, passToTest
+	return packageNames, passToTest, passToBin
 }
 
 // parseTestFlag sees if argument i is a known flag and returns its

--- a/gocov/test.go
+++ b/gocov/test.go
@@ -78,8 +78,8 @@ func runTests(args []string) error {
 	// later merged into a single file.
 	for i, pkg := range pkgs {
 		coverFile := filepath.Join(tmpDir, fmt.Sprintf("test%d.cov", i))
-		cmdArgs := append([]string{"test", "-coverprofile", coverFile}, testFlags...)
-		cmdArgs = append(cmdArgs, pkg)
+		cmdArgs := append([]string{"test", "-coverprofile", coverFile}, pkg)
+		cmdArgs = append(cmdArgs, testFlags...)
 		cmd := exec.Command("go", cmdArgs...)
 		cmd.Stdin = nil
 		// Write all test command output to stderr so as not to interfere with

--- a/gocov/test.go
+++ b/gocov/test.go
@@ -57,7 +57,7 @@ func resolvePackages(pkgs []string) ([]string, error) {
 }
 
 func runTests(args []string) error {
-	pkgs, testFlags := testflag.Split(args)
+	pkgs, testFlags, binFlags := testflag.Split(args)
 	pkgs, err := resolvePackages(pkgs)
 	if err != nil {
 		return err
@@ -78,8 +78,11 @@ func runTests(args []string) error {
 	// later merged into a single file.
 	for i, pkg := range pkgs {
 		coverFile := filepath.Join(tmpDir, fmt.Sprintf("test%d.cov", i))
-		cmdArgs := append([]string{"test", "-coverprofile", coverFile}, pkg)
-		cmdArgs = append(cmdArgs, testFlags...)
+		cmdArgs := append([]string{"test", "-coverprofile", coverFile}, testFlags...)
+		cmdArgs = append(cmdArgs, pkg)
+		cmdArgs = append(cmdArgs, "-args")
+		cmdArgs = append(cmdArgs, binFlags...)
+		log.Print("Running: go", cmdArgs)
 		cmd := exec.Command("go", cmdArgs...)
 		cmd.Stdin = nil
 		// Write all test command output to stderr so as not to interfere with


### PR DESCRIPTION
when the package test has it options, they must come after package name, not before it
