### PR TITLE
fix (convert): syscalls optimizations

### DIFF
--- a/gocov/main.go
+++ b/gocov/main.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/axw/gocov"
@@ -41,8 +42,8 @@ func usage() {
 	os.Exit(2)
 }
 
-func marshalJson(packages []*gocov.Package) ([]byte, error) {
-	return json.Marshal(struct{ Packages []*gocov.Package }{packages})
+func marshalJson(w io.Writer, packages []*gocov.Package) error {
+	return json.NewEncoder(w).Encode(struct{ Packages []*gocov.Package }{packages})
 }
 
 func unmarshalJson(data []byte) (packages []*gocov.Package, err error) {


### PR DESCRIPTION
The function "build.Import" is called for one file in the package. Because in the function "build.Import" exists syscall [exec.Command](https://golang.org/src/go/build/build.go?s=42252:42319#L1103). 