### PR TITLE
Move Convert to a sub-package

### DIFF
--- a/gocov/convert/convert_test.go
+++ b/gocov/convert/convert_test.go
@@ -1,4 +1,4 @@
-package main
+package convert
 
 import (
 	"go/ast"

--- a/gocov/main.go
+++ b/gocov/main.go
@@ -28,6 +28,7 @@ import (
 	"os"
 
 	"github.com/axw/gocov"
+	"github.com/axw/gocov/gocov/convert"
 )
 
 func usage() {
@@ -68,10 +69,12 @@ func main() {
 				fmt.Fprintln(os.Stderr, "missing cover profile")
 				os.Exit(1)
 			}
-			if err := convertProfiles(flag.Args()[1:]...); err != nil {
+			out, err := convert.ConvertProfiles(flag.Args()[1:]...)
+			if err != nil {
 				fmt.Fprintln(os.Stderr, "error:", err)
 				os.Exit(1)
 			}
+			os.Stdout.Write(out)
 		case "annotate":
 			os.Exit(annotateSource())
 		case "report":

--- a/gocov/test.go
+++ b/gocov/test.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/axw/gocov/gocov/convert"
 	"github.com/axw/gocov/gocov/internal/testflag"
 )
 
@@ -100,5 +101,7 @@ func runTests(args []string) error {
 	}
 
 	// Merge the profiles.
-	return convertProfiles(files...)
+	out, err := convert.ConvertProfiles(files...)
+	os.Stdout.Write(out)
+	return err
 }


### PR DESCRIPTION
Move Convert to a sub-package to make it possible to run from other tools as an API